### PR TITLE
Change Parser prod port to 8080

### DIFF
--- a/backend/Dockerfile-parser
+++ b/backend/Dockerfile-parser
@@ -19,8 +19,7 @@ RUN dotnet publish -c Release -o /app/publish
 # final stage/image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
 
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
 
 WORKDIR /app
 COPY --from=build /app/publish .
@@ -30,5 +29,7 @@ COPY --from=build /app/publish .
 #RUN apk add --no-cache icu-libs
 #ENV LC_ALL en_US.UTF-8
 #ENV LANG en_US.UTF-8
+
+ENV ASPNETCORE_URLS=http://*:8080
 
 ENTRYPOINT ["dotnet", "Code4Ro.CoViz19.Parser.dll"]


### PR DESCRIPTION
Due to a limitation in Fargate, we cannot have multiple containers with the same internal port in the same Task definition.

The Parser container is part of the Backend service, thus running in the same task definition with the API container.