### PR TITLE
Api URL environment variable

### DIFF
--- a/frontend/src/config/globals.jsx
+++ b/frontend/src/config/globals.jsx
@@ -1,6 +1,7 @@
 export const Constants = {
-  // TODO: dev vs prod
-  api: 'https://code4rocoviz19api-demo.azurewebsites.net/api/v1',
+  api: process.env.REACT_APP_API_URL || 'https://code4rocoviz19api-demo.azurewebsites.net/api/v1',
+  isDev: process.env.NODE_ENV === 'development',
+  isProd: process.env.NODE_ENV === 'production',
 
   womenColor: '#F77EB9',
   menColor: '#7EBCFF',
@@ -11,7 +12,6 @@ export const Constants = {
 
   countyLowestColor: '#7EBCFF',
   countyHighestColor: 'red',
-
 
   womenText: 'Femei',
   menText: 'Bărbați'


### PR DESCRIPTION
### What does it fix?

Closes #87 

- added `REACT_APP_API_URL` env var to set up api, defaults to the one we're using internally to test

### How has it been tested?

Manually