### PR TITLE
Use access role for ECS to S3

### DIFF
--- a/aws_deploy/service.tf
+++ b/aws_deploy/service.tf
@@ -153,6 +153,7 @@ module "parser" {
   ]
 
   container_port        = 8080
+  task_role_arn         = aws_iam_role.ecs_instance.arn
   execution_role_arn    = aws_iam_role.ecs_execution.arn
   image                 = var.IMAGE_PARSER
   prefix                = local.name

--- a/aws_deploy/service/main.tf
+++ b/aws_deploy/service/main.tf
@@ -11,7 +11,7 @@ module "load-balancer" {
 resource "aws_ecs_service" "main" {
   name            = var.name
   cluster         = var.cluster
-  task_definition = aws_ecs_task_definition.main.id
+  task_definition = "${aws_ecs_task_definition.main.id}:${aws_ecs_task_definition.main.revision}"
   desired_count   = 1
   launch_type     = "FARGATE"
 
@@ -39,6 +39,7 @@ resource "aws_ecs_task_definition" "main" {
 
   cpu                   = 256
   memory                = 512
+  task_role_arn         = var.task_role_arn
   execution_role_arn    = var.execution_role_arn
   container_definitions = <<DEFINITION
 [

--- a/aws_deploy/service/variables.tf
+++ b/aws_deploy/service/variables.tf
@@ -30,6 +30,11 @@ variable "container_port" {
   type = number
 }
 
+variable "task_role_arn" {
+  type    = string
+  default = ""
+}
+
 variable "execution_role_arn" {
   type = string
 }


### PR DESCRIPTION
* create a role for ECS task to be able to call S3
* use common policy for ECS task role and Parser User
* Set S3 policy for public access

* Set Task definition revision in service to avoid redundant apply actions