### PR TITLE
Split parser to it's own certificate & remove from output

### DIFF
--- a/aws_deploy/dns.tf
+++ b/aws_deploy/dns.tf
@@ -27,9 +27,17 @@ module "parser_dns" {
 resource "aws_acm_certificate" "cert" {
   domain_name = module.front-end_dns.fqdn
   subject_alternative_names = [
-    module.api_dns.fqdn,
-    module.parser_dns.fqdn
+    module.api_dns.fqdn
   ]
+
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "parser" {
+  domain_name = module.parser_dns.fqdn
 
   validation_method = "DNS"
   lifecycle {
@@ -54,10 +62,10 @@ resource "aws_route53_record" "cert_validation-api" {
 }
 
 resource "aws_route53_record" "cert_validation-parser" {
-  name    = aws_acm_certificate.cert.domain_validation_options.2.resource_record_name
-  type    = aws_acm_certificate.cert.domain_validation_options.2.resource_record_type
+  name    = aws_acm_certificate.parser.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.parser.domain_validation_options.0.resource_record_type
   zone_id = data.aws_route53_zone.main.zone_id
-  records = [aws_acm_certificate.cert.domain_validation_options.2.resource_record_value]
+  records = [aws_acm_certificate.parser.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 

--- a/aws_deploy/output.tf
+++ b/aws_deploy/output.tf
@@ -6,22 +6,10 @@ output "DNS_API" {
   value = "https://${module.api_dns.fqdn}"
 }
 
-output "DNS_Parser" {
-  value = "https://${module.parser_dns.fqdn}"
-}
-
 output "LB_FrontEnd" {
   value = module.front-end.dns
 }
 
 output "LB_API" {
   value = module.api.dns
-}
-
-output "LB_Parser" {
-  value = module.parser.dns
-}
-
-output "NAT_Egress_Elastic_IP" {
-  value = aws_eip.private.*.public_ip
 }


### PR DESCRIPTION
Close #125 

This implementation does:

* removes the printing of the Parser domain
* Gives the Parser it's own certificate to keep HTTPS, and not expose the parser domain in the list of domains from the main certificate

This implementation not:

* Protect people from guessing the Parser domain by reading the Terraform code for this deployment

----

**The Parser should still be secured and password protected before going to production!!**