### PR TITLE
Run TF checks in parallel wth Docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,6 @@ jobs:
   check-infra:
     name: Test Infrastructure
     runs-on: ubuntu-latest
-    needs: [build-parser, build-api, build-frontend]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Makes the TF checks finish faster, not having to wait for the Docker builds to finish.

**NOTE** This is only acceptable in the regular CI workflow. This IS NOT OK for the actual deployment.