### PR TITLE
Added complete flag to daily stats

### DIFF
--- a/frontend/src/components/pages/dashboard.jsx
+++ b/frontend/src/components/pages/dashboard.jsx
@@ -112,19 +112,25 @@ export class Dashboard extends React.PureComponent {
     const startDateStr = this.formattedShortDateString(this.dateFromTimestamp(startDate));
     const endDateStr = this.formattedShortDateString(this.dateFromTimestamp(endDate));
 
-    const symptomaticCasesHistory = history.map((entry) => { return Math.max(entry.monitored, 0) });
-    const confirmedCasesHistory = history.map((entry) => { return Math.max(entry.infected, 0) });
-    const curedCasesHistory = history.map((entry) => { return Math.max(entry.cured, 0) });
-    const deathCasesHistory = history.map((entry) => {return Math.max(entry.deaths, 0)});
-    const dateStrings = history.map((entry) =>
-      this.formattedShortDateString(this.dateFromTimestamp(entry.datePublished)));
+    const confirmedCasesHistory = history.flatMap((entry) => { 
+      return entry.complete === false ? [] : Math.max(entry.infected, 0) 
+    });
+    const curedCasesHistory = history.flatMap((entry) => {
+      return entry.complete === false ? [] : Math.max(entry.cured, 0) 
+    });
+    const deathCasesHistory = history.flatMap((entry) => {
+      return entry.complete === false ? [] : Math.max(entry.deaths, 0)
+    });
+    const dateStrings = history.flatMap((entry) => {
+      return entry.complete === false ? [] : this.formattedShortDateString(this.dateFromTimestamp(entry.datePublished))
+    });
+      
 
     return {
       isLoaded: true,
       startDate: startDateStr,
       endDate: endDateStr,
       dates: dateStrings,
-      symptomaticCasesHistory: symptomaticCasesHistory,
       confirmedCasesHistory: confirmedCasesHistory,
       curedCasesHistory: curedCasesHistory,
       deathCasesHistory: deathCasesHistory,


### PR DESCRIPTION
### What does it fix?

If a daily entry has the `complete` flag set to `false`, the bar will not be displayed for that day. If it's `true` or missing the bar will be displayed.

### How has it been tested?

With mockup data, API is not done yet.