### PR TITLE
Feature/tooltip stacking order

### DIFF
--- a/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
+++ b/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
@@ -46,6 +46,8 @@ export class CasesPerDayCard extends React.PureComponent {
     const labels = ['Confirmați', 'Vindecați', 'Decedaţi'];
     const chartType =
       this.state.activeTab === VIEW_TABS[0].value ? 'bar' : 'line';
+    const tooltipItemColorStyle = 'border-radius: 50%; margin-right: 6px; width: 10px; height: 10px;'
+    const tooltipItemStyle = 'height: 20px; display: flex; flex-wrap: nowrap; align-items: center;'
     const chartStack = chartType === 'bar' ? 'one' : false;
     const zoomStart = this.getZoomStartPercentage(dates);
 
@@ -70,6 +72,22 @@ export class CasesPerDayCard extends React.PureComponent {
         axisPointer: {
           axis: 'x',
         },
+        formatter: function(params){
+          console.log(params)
+          const date = `${params[0].axisValueLabel}`
+          const cases = params.map((param) => `
+          <span style="${tooltipItemStyle}">
+            <span
+            style="${tooltipItemColorStyle} background-color: ${param.color};"
+            ></span>
+            <p style={"text-align: right;"}>${param.seriesName}: ${param.value}</p>
+          </span>`)
+          const tooltipBox = `
+            ${date}
+            ${cases.reverse().join('')}
+          `
+          return tooltipBox
+        }
       },
       legend: {
         data: labels,

--- a/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
+++ b/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
@@ -73,7 +73,6 @@ export class CasesPerDayCard extends React.PureComponent {
           axis: 'x',
         },
         formatter: function(params){
-          console.log(params)
           const date = `${params[0].axisValueLabel}`
           const cases = params.map((param) => `
           <span style="${tooltipItemStyle}">
@@ -82,11 +81,11 @@ export class CasesPerDayCard extends React.PureComponent {
             ></span>
             <p style={"text-align: right;"}>${param.seriesName}: ${param.value}</p>
           </span>`)
-          const tooltipBox = `
+
+          return `
             ${date}
             ${cases.reverse().join('')}
           `
-          return tooltipBox
         }
       },
       legend: {


### PR DESCRIPTION
### What does it fix?

It fixes #389 

- It is changing the order of the tooltip items to make it similar to the bars shown in the "Cazuri pe zi" chart.
- It uses the  `tooltip.formatter` [here](https://echarts.apache.org/en/option.html#tooltip.formatter) to manually build the tooltip and reorder the items in that array. 

## Suggestion
- [ ] Considering that the order is always from top to bottom "decedati, vindecati, confirmati", the legend should also have that order from left to right. What do you think?

### How has it been tested?

The feature has been tested manually. The result can be seen in the vercel staging deployment. 