### PR TITLE
Update running instructions in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo](src/images/logo-coviz.svg)
 
-# Date la zi • [Live](https://datelazi.ro/) 
+# Date la zi • [Live](https://datelazi.ro/)
 
 ## Vizualization App to track the COVID-19 virus epidemic
 
@@ -51,7 +51,7 @@ yarn
 ### Run the project in development mode
 
 ```
-yarn start
+yarn run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.


### PR DESCRIPTION
### What does it fix?

The running instructions in the `README.md` file are incorrect. If you run `yarn start` it will try to run the Next.js production server. To run a local dev server, `yarn run dev` must be used.