### PR TITLE
Add accessibility tables for specified graphs

### DIFF
--- a/components/accessibility-table.jsx
+++ b/components/accessibility-table.jsx
@@ -1,0 +1,33 @@
+/// Renders the data in a tabular format, for screen reader consumption.
+export const AccessibilityTable = (props) => {
+  const columnNames = props.columns.map((c) => c.name)
+  const dataLength = props.columns[0].data.length
+  // Truncate results to last 14 days
+  const numRows = Math.min(14, dataLength)
+  // If the data is stale, we do not want to show today's info
+  const firstIndex = props.isStale ? 1 : 0
+  let rows = []
+
+  for (let rowIndex = firstIndex; rowIndex < numRows; ++rowIndex) {
+    const cells = columnNames.map((_, columnIndex) => (
+      <td key={columnIndex}>
+        {props.columns[columnIndex].data[dataLength - rowIndex - 1]}
+      </td>
+    ))
+    const row = <tr key={rowIndex}>{cells}</tr>
+    rows.push(row)
+  }
+
+  return (
+    <table className="is-sr-only">
+      <thead>
+        <tr>
+          {columnNames.map((name) => (
+            <th key={name}>{name}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </table>
+  )
+}

--- a/components/cards/age-category/age-category.jsx
+++ b/components/cards/age-category/age-category.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Card } from '../../layout/card/card'
+import { AccessibilityTable } from '../../accessibility-table'
 import { formatDate } from '../../../utils/date'
 import { parseAgeCategory } from '../../../utils/parse'
 import { getLegendLabels, getSelectedState } from '../../../utils/echarts'
@@ -110,6 +111,16 @@ export class AgeCategory extends React.PureComponent {
           }}
           option={this.getChartOptions(parsedData)}
           onEvents={{ legendselectchanged: this.onChartLegendselectchanged }}
+        />
+        <AccessibilityTable
+          isStale={stale}
+          columns={[
+            { name: 'Data', data: parsedData.dateStrings },
+            ...Object.entries(parsedData.ageCategories).map(([name, data]) => ({
+              name,
+              data,
+            })),
+          ]}
         />
       </Card>
     )

--- a/components/cards/age/age.jsx
+++ b/components/cards/age/age.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Card } from '../../layout/card/card'
+import { AccessibilityTable } from '../../accessibility-table'
 import { Constants } from '../../../config/globals'
 import { formatDate } from '../../../utils/date'
 import { parseAgeStats } from '../../../utils/parse'
@@ -76,6 +77,7 @@ export class AgeCard extends React.PureComponent {
   render() {
     const { title, state } = this.props
     const { error, lastUpdatedOn, stale, ...parsedData } = parseAgeStats(state)
+    const data = parsedData.data
     return (
       <Card
         error={error}
@@ -94,6 +96,14 @@ export class AgeCard extends React.PureComponent {
               width: '100%',
             }}
             option={this.getChartOptions(parsedData)}
+          />
+          <AccessibilityTable
+            isStale={stale}
+            columns={[
+              { name: 'Categorie', data: data.map((o) => o.name) },
+              { name: 'Procent', data: data.map((o) => o.percentage) },
+              { name: 'Total', data: data.map((o) => o.value) },
+            ]}
           />
         </div>
       </Card>

--- a/components/cards/cases-per-day-card/cases-per-day-card.jsx
+++ b/components/cards/cases-per-day-card/cases-per-day-card.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Card } from '../../layout/card/card'
 import { Tabs } from '../../layout/tabs/tabs'
+import { AccessibilityTable } from '../../accessibility-table'
 import { Constants } from '../../../config/globals'
 import { formatDate } from '../../../utils/date'
 import { parseDailyStats } from '../../../utils/parse'
@@ -168,6 +169,15 @@ export class CasesPerDayCard extends React.PureComponent {
           tabList={VIEW_TABS}
           activeTab={activeTab}
           onSelect={this.handleClickTab}
+        />
+        <AccessibilityTable
+          isStale={isStale}
+          columns={[
+            { name: 'Data', data: records.dates },
+            { name: 'Cazuri confirmate', data: records.confirmedCasesHistory },
+            { name: 'Cazuri vindecate', data: records.curedCasesHistory },
+            { name: 'Decese', data: records.deathCasesHistory },
+          ]}
         />
       </Card>
     )

--- a/components/cards/vaccines-per-day-card/vaccines-per-day-card.jsx
+++ b/components/cards/vaccines-per-day-card/vaccines-per-day-card.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Card } from '../../layout/card/card'
+import { AccessibilityTable } from '../../accessibility-table'
 import { Constants } from '../../../config/globals'
 import { Tabs } from '../../layout/tabs/tabs'
 import { formatDate } from '../../../utils/date'
@@ -164,6 +165,16 @@ export class VaccinesPerDayCard extends React.PureComponent {
           tabList={VIEW_TABS}
           activeTab={activeTab}
           onSelect={this.handleClickTab}
+        />
+        <AccessibilityTable
+          isStale={isStale}
+          columns={[
+            { name: 'Data', data: records.dates },
+            { name: 'Pfizer BioNTech', data: records.pfizer },
+            { name: 'Moderna', data: records.moderna },
+            { name: 'AstraZeneca', data: records.astraZeneca },
+            { name: 'Johnson&Johnson', data: records.johnsonAndJohnson },
+          ]}
         />
         <p>
           În cazul vaccinelor Pfizer BioNTech, Moderna și AstraZeneca sunt


### PR DESCRIPTION
### What does it fix?

Renders the statistical data in a tabular format, visible only to screen readers.

Closes #425 

### How has it been tested?

This is how the tables look like if the `is-sr-only` class is removed from them:

![image](https://user-images.githubusercontent.com/3010346/120064814-dceb1580-c076-11eb-8ccd-0ea195db095f.png)

![image](https://user-images.githubusercontent.com/3010346/120064820-e2e0f680-c076-11eb-97ac-2cd9d088b7cb.png)

![image](https://user-images.githubusercontent.com/3010346/120064825-e7a5aa80-c076-11eb-9743-ba989895f5d5.png)

![image](https://user-images.githubusercontent.com/3010346/120064839-effde580-c076-11eb-8c90-fb443e318ed7.png)

