### PR TITLE
Add lang="ro" attribute to HTML tag

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,22 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html lang="ro">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?

By setting the language on the `<html>` tag, screen readers should switch to a Romanian locale voice if it's available.

This also has the side effect of allowing extensions like Google Translate to offer to translate the website to the user's local language if it's different.

[Most of the commit is boilerplate.](https://nextjs.org/docs/advanced-features/custom-document) Next.js only allows you to add/remove attributes from the `<html>` tag by declaring a _document file.


<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

I fired up VoiceOver on Safari on macOS and confirmed that the TTS voice dynamically changes. I tried to do a screen recording but couldn't get SoundFlower working.
