### PR TITLE
Replace auto-generated accessible label on charts

### DIFF
--- a/components/cards/summary/summary-card.jsx
+++ b/components/cards/summary/summary-card.jsx
@@ -7,9 +7,6 @@ import { SUMMARY_CHART_THEME } from './summary-chart.theme'
 export class SummaryCard extends React.PureComponent {
   getChartOptions(data) {
     return {
-      aria: {
-        show: true,
-      },
       xAxis: {
         type: 'category',
         xAxisData: data.xAxisData,
@@ -37,6 +34,9 @@ export class SummaryCard extends React.PureComponent {
       embedPath,
       stale,
     } = this.props
+
+    const chartLabelId = `chart-label-${embedPath}`;
+
     return (
       <Card
         error={error}
@@ -45,7 +45,7 @@ export class SummaryCard extends React.PureComponent {
         title={title}
         subtitle={subTitle}
       >
-        <h3 className="is-inline-block">{total}</h3>
+        <h3 id={chartLabelId} className="is-inline-block">{total}</h3>
         {special && (
           <span className={`${styles.special} is-inline-block`}>
             <span
@@ -60,7 +60,7 @@ export class SummaryCard extends React.PureComponent {
           </span>
         )}
         {data && (
-          <div className={styles.mini_chart}>
+          <div className={styles.mini_chart} aria-labelledby={chartLabelId}>
             <ReactECharts
               lazyUpdate
               opts={{ renderer: 'svg' }}


### PR DESCRIPTION
### What does it fix?

[Echarts can auto-generate aria labels for charts](https://echarts.apache.org/en/option.html#aria.label). However, these labels are not ideal.

For example, for a chart displaying the number of daily confirmed cases (currently `1,081,875`), the auto-generated aria label is:

```
aria-label="This is a chart with type Line chart.The first 10 items are: the data for 0 is 217, the data for 1 is 260, the data for 2 is 277, the data for 3 is 308, the data for 4 is 367, the data for 5 is 433, the data for 6 is 576, the data for 7 is 762, the data for 8 is 906, the data for 9 is 1029. "
```

There are two problems with this label:

- The text is in English whereas the rest of the website is in Romanian
- The information is fairly verbose, and the data points are not actual case numbers

Instead of using the auto-generated label, we can simply assign a unique `id` on the neighbouring header which contains the daily confirmed cases, and then associate that label with the chart through `aria-labelledby`.

This gives us a label like:

```
1,046,952
96.77% din total
```

### How has it been tested?

Using VoiceOver on macOS in Safari.