### PR TITLE
Fix horizontal scroll when not on sr.

### DIFF
--- a/components/accessibility-table.jsx
+++ b/components/accessibility-table.jsx
@@ -19,15 +19,17 @@ export const AccessibilityTable = (props) => {
   }
 
   return (
-    <table className="is-sr-only">
-      <thead>
-        <tr>
-          {columnNames.map((name) => (
-            <th key={name}>{name}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>{rows}</tbody>
-    </table>
+    <div className="is-sr-only">
+      <table>
+        <thead>
+          <tr>
+            {columnNames.map((name) => (
+              <th key={name}>{name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
   )
 }


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

https://user-images.githubusercontent.com/2974519/127166464-b44101c3-fab5-4c5e-a35f-e960ec31b3cc.MOV

When going on the homepage from a mobile device and is not a screen reader, you are able to scroll horizontally which is not great. 

Wrapping the `<AccessibilityTable />` in  a `div` with the same class name fixes the problem.

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

Accessing the website from my iPhone and Chrome.

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
